### PR TITLE
fix(dashboard): product CRUD form lifecycle and rename+reupload race

### DIFF
--- a/src/Components/Dashboard/AddProduct.jsx
+++ b/src/Components/Dashboard/AddProduct.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import { useSelector, useDispatch } from "react-redux"
 import * as yup from "yup"
 import { yupResolver } from "@hookform/resolvers/yup"
@@ -8,6 +8,7 @@ import { v4 as uuid } from "uuid"
 import { Box, Button, Container, Typography, TextField, CircularProgress } from "@mui/material"
 import { PhotoCamera, Delete as DeleteIcon } from "@mui/icons-material"
 import productSlice from "../../Redux/Product/ProductSlice"
+import { PLACEHOLDER_IMG } from "./constants"
 
 const { setProductDataToFirestore } = productSlice.actions
 
@@ -36,18 +37,15 @@ const AddProduct = () => {
     })
     const [tabImageList, setTabImageList] = useState([])
     const dispatch = useDispatch()
-    useEffect(() => {
-        setUploadProductInfo({
-            ...uploadProductInfo,
-            productId: uuid(),
-        })
-    }, [productsData.length])
+    const submittedRef = useRef(false)
+    const prevProductCountRef = useRef(productsData.length)
 
     useEffect(() => {
-        setUploadProductInfo({
-            ...uploadProductInfo,
-            tabImageList,
-        })
+        setUploadProductInfo(prev => ({ ...prev, productId: uuid() }))
+    }, [])
+
+    useEffect(() => {
+        setUploadProductInfo(prev => ({ ...prev, tabImageList }))
     }, [tabImageList])
 
     const formValidate = yup.object().shape({
@@ -70,19 +68,32 @@ const AddProduct = () => {
         desc: yup.string().required("欄位不得為空"),
         tabDesc: yup.string().required("欄位不得為空"),
         deliveryDesc: yup.string().required("欄位不得為空"),
-        imageUpload: yup
-            .mixed()
-            .test("required", "請上傳商品圖片", files => files && files.length > 0),
+        imageUpload: yup.mixed().test("required", "請上傳商品圖片", files => files && files.length > 0),
     })
 
     const {
         register,
         handleSubmit,
         control,
+        reset,
         formState: { errors },
     } = useForm({
         resolver: yupResolver(formValidate),
     })
+
+    useEffect(() => {
+        const grew = productsData.length > prevProductCountRef.current
+        if (submittedRef.current && grew) {
+            submittedRef.current = false
+            setUploadProductInfo({ ...initUploadProduct, productId: uuid() })
+            setImageUpload({ imageFile: {}, imageUrl: "" })
+            setTabImageList([])
+            reset()
+            const fileInput = document.getElementById("imageUpload")
+            if (fileInput) fileInput.value = ""
+        }
+        prevProductCountRef.current = productsData.length
+    }, [productsData.length, reset])
 
     const handleChange = (e, inputId) => {
         switch (inputId) {
@@ -176,11 +187,12 @@ const AddProduct = () => {
     const handleFormSubmit = () => {
         confirmAlert({
             title: `上傳商品`,
-            message: `確定要上傳${uploadProductInfo.title}?`,
+            message: `確定要上傳 ${uploadProductInfo.title} 商品?`,
             buttons: [
                 {
                     label: "是",
                     onClick: () => {
+                        submittedRef.current = true
                         dispatch(
                             setProductDataToFirestore({
                                 uploadProductInfo: {
@@ -188,7 +200,7 @@ const AddProduct = () => {
                                     mainImg: imageUrl,
                                 },
                                 imageFile,
-                            })
+                            }),
                         )
                     },
                 },
@@ -213,7 +225,7 @@ const AddProduct = () => {
     const { imageFile, imageUrl } = imageUpload
     return (
         <Box>
-            {productLoading ? (
+            {productLoading ?
                 <CircularProgress
                     sx={{
                         position: "absolute",
@@ -222,8 +234,7 @@ const AddProduct = () => {
                         transform: "translate(-35%, -50%)",
                     }}
                 />
-            ) : (
-                <>
+            :   <>
                     <Box
                         component="form"
                         sx={{
@@ -446,11 +457,7 @@ const AddProduct = () => {
                                         startAdornment: (
                                             <Box
                                                 component="img"
-                                                src={
-                                                    imageUrl !== ""
-                                                        ? imageUrl
-                                                        : "https://fakeimg.pl/250x200/?text=預覽圖&font=noto"
-                                                }
+                                                src={imageUrl !== "" ? imageUrl : PLACEHOLDER_IMG}
                                                 sx={{
                                                     objectFit: "contain",
                                                     width: "250px",
@@ -630,7 +637,7 @@ const AddProduct = () => {
                         </Box>
                     </Box>
                 </>
-            )}
+            }
         </Box>
     )
 }

--- a/src/Components/Dashboard/Dashboard.jsx
+++ b/src/Components/Dashboard/Dashboard.jsx
@@ -1,6 +1,8 @@
 import React from "react"
 import { Link as RouteLink, Outlet } from "react-router-dom"
 import { Container, List, ListItemButton, ListItemText } from "@mui/material"
+import "react-confirm-alert/src/react-confirm-alert.css"
+import "./confirmAlert.css"
 
 const Dashboard = () => {
     return (

--- a/src/Components/Dashboard/EditProduct.jsx
+++ b/src/Components/Dashboard/EditProduct.jsx
@@ -1,22 +1,25 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import { useSelector, useDispatch } from "react-redux"
 import { confirmAlert } from "react-confirm-alert"
 import * as yup from "yup"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { useForm } from "react-hook-form"
-import { Box, Button, TextField, Typography, InputLabel, MenuItem, FormControl, Select, CircularProgress  } from "@mui/material"
-import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import {
-    // setUpdateSelectedProductToFirestore,
-    setUploadProductImageToStorage,
-    setProductTabImageToStorage,
-} from "../../Utils/firebase"
+    Box,
+    Button,
+    TextField,
+    Typography,
+    InputLabel,
+    MenuItem,
+    FormControl,
+    Select,
+    CircularProgress,
+} from "@mui/material"
+import PhotoCamera from "@mui/icons-material/PhotoCamera"
 import productSlice from "../../Redux/Product/ProductSlice"
+import { PLACEHOLDER_IMG } from "./constants"
 
-const {
-    getProductsData,
-    setUpdateSelectedProductToFirestore,
-} = productSlice.actions
+const { getProductsData, setUpdateSelectedProductToFirestore } = productSlice.actions
 
 const EditProduct = () => {
     const [productTitle, setProductTitle] = useState("")
@@ -44,6 +47,7 @@ const EditProduct = () => {
     } = editProductInfo
     const { imageUrl, imageFile, fileLength } = imageUpload
     const dispatch = useDispatch()
+    const submittedRef = useRef(false)
 
     useEffect(() => {
         dispatch(getProductsData())
@@ -59,10 +63,22 @@ const EditProduct = () => {
     const {
         register,
         handleSubmit,
+        reset,
         formState: { errors },
     } = useForm({
         resolver: yupResolver(formValidate),
     })
+
+    useEffect(() => {
+        if (submittedRef.current) {
+            submittedRef.current = false
+            setProductTitle("")
+            setEditProductInfo({})
+            setImageUpload({ imageFile: {}, imageUrl: "", fileLength: 0 })
+            setUploadTabImageList([])
+            reset()
+        }
+    }, [productsData, reset])
 
     const handleChange = event => {
         setProductTitle(event.target.value)
@@ -71,18 +87,18 @@ const EditProduct = () => {
         setImageUpload({
             imageFile: {},
             imageUrl: productsData[selectedImageIndex].mainImg,
-            fileLength: 0
+            fileLength: 0,
         })
     }
 
     const handleChangeMainImage = event => {
         const file = event.target.files[0]
-        if(file) {
+        if (file) {
             setImageUpload(prevState => ({
                 ...prevState,
                 imageFile: file,
                 imageUrl: URL.createObjectURL(file),
-                fileLength: event.target.files.length
+                fileLength: event.target.files.length,
             }))
         }
     }
@@ -169,23 +185,25 @@ const EditProduct = () => {
         }
     }
 
-
     const handleEditClick = () => {
         confirmAlert({
             title: `編輯商品`,
-            message: `確定要編輯${editProductInfo.title}?`,
+            message: `確定要編輯 ${editProductInfo.title} 商品?`,
             buttons: [
                 {
                     label: "是",
                     onClick: () => {
-                        setUploadProductImageToStorage(imageFile, productTitle, fileLength)
-                        setProductTabImageToStorage(uploadTabImageList)
-                        dispatch(setUpdateSelectedProductToFirestore({
-                            ...editProductInfo,
-                            mainImg: imageUrl
-                        }))
+                        submittedRef.current = true
+                        dispatch(
+                            setUpdateSelectedProductToFirestore({
+                                ...editProductInfo,
+                                originalTitle: productTitle,
+                                imageFile,
+                                fileLength,
+                                tabImageFiles: uploadTabImageList,
+                            }),
+                        )
                     },
-
                 },
                 {
                     label: "否",
@@ -208,218 +226,217 @@ const EditProduct = () => {
                     lg: "calc( 95vh - 68.5px - 128px - 108px )",
                 },
             }}>
-                {
-                    productLoading
-                        ? <CircularProgress />
-                        : (
-                            <>
-                                <FormControl sx={{ m: 1, minWidth: 160 }}>
-                                    <InputLabel id="remove-product">選擇編輯的商品</InputLabel>
-                                    <Select
-                                        labelId="remove-product"
-                                        id="demo-simple-select-autowidth"
-                                        value={productTitle}
-                                        onChange={handleChange}
-                                        autoWidth
-                                        label="選擇編輯的商品">
-                                        {productsData.map(product => {
-                                            return (
-                                                <MenuItem key={product.title} value={product.title}>
-                                                    {product.title}
-                                                </MenuItem>
-                                            )
-                                        })}
-                                    </Select>
-                                </FormControl>
-                                <Box
-                                    component="form"
-                                    sx={{
-                                        "& .MuiTextField-root": {
-                                            mt: 3,
-                                            width: { xs: "38ch", lg: "50ch" },
-                                        },
-                                        display: "inline-flex",
-                                        flexWrap: "wrap",
-                                        justifyContent: "center",
-                                        gap: "10px",
-                                    }}
-                                    noValidate
-                                    autoComplete="off">
-                                    <TextField
-                                        id="productName"
-                                        label="商品名稱 (productName)"
-                                        type="text"
-                                        value={title}
-                                        onChange={e => {
-                                            handleEditChange(e, "productName")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        sx={{
-                                            display: "none",
-                                        }}
-                                        id="productId"
-                                        label="商品編號 (id)"
-                                        type="hidden"
-                                        value={productId}
-                                        onChange={e => {
-                                            handleEditChange(e, "productId")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        id="originalPrice"
-                                        label="原始價格 (originalPrice)"
-                                        type="number"
-                                        value={originalPrice}
-                                        onChange={e => {
-                                            handleEditChange(e, "originalPrice")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        id="discountPrice"
-                                        label="折扣價格 (discountPrice)"
-                                        type="number"
-                                        value={discountPrice}
-                                        onChange={e => {
-                                            handleEditChange(e, "discountPrice")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        id="stock"
-                                        label="商品庫存 (stock)"
-                                        type="number"
-                                        value={stock}
-                                        onChange={e => {
-                                            handleEditChange(e, "stock")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
+            {productLoading ?
+                <CircularProgress />
+            :   <>
+                    <FormControl sx={{ m: 1, minWidth: 160 }}>
+                        <InputLabel id="remove-product">選擇編輯的商品</InputLabel>
+                        <Select
+                            labelId="remove-product"
+                            id="demo-simple-select-autowidth"
+                            value={productTitle}
+                            onChange={handleChange}
+                            autoWidth
+                            label="選擇編輯的商品">
+                            {productsData.map(product => {
+                                return (
+                                    <MenuItem
+                                        key={product.title}
+                                        value={product.title}>
+                                        {product.title}
+                                    </MenuItem>
+                                )
+                            })}
+                        </Select>
+                    </FormControl>
+                    <Box
+                        component="form"
+                        sx={{
+                            "& .MuiTextField-root": {
+                                mt: 3,
+                                width: { xs: "38ch", lg: "50ch" },
+                            },
+                            display: "inline-flex",
+                            flexWrap: "wrap",
+                            justifyContent: "center",
+                            gap: "10px",
+                        }}
+                        noValidate
+                        autoComplete="off">
+                        <TextField
+                            id="productName"
+                            label="商品名稱 (productName)"
+                            type="text"
+                            value={title}
+                            onChange={e => {
+                                handleEditChange(e, "productName")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            sx={{
+                                display: "none",
+                            }}
+                            id="productId"
+                            label="商品編號 (id)"
+                            type="hidden"
+                            value={productId}
+                            onChange={e => {
+                                handleEditChange(e, "productId")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            id="originalPrice"
+                            label="原始價格 (originalPrice)"
+                            type="number"
+                            value={originalPrice}
+                            onChange={e => {
+                                handleEditChange(e, "originalPrice")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            id="discountPrice"
+                            label="折扣價格 (discountPrice)"
+                            type="number"
+                            value={discountPrice}
+                            onChange={e => {
+                                handleEditChange(e, "discountPrice")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            id="stock"
+                            label="商品庫存 (stock)"
+                            type="number"
+                            value={stock}
+                            onChange={e => {
+                                handleEditChange(e, "stock")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
 
-                                    <TextField
+                        <TextField
+                            sx={{
+                                display: "none",
+                            }}
+                            id="read-only-quantity"
+                            label="商品目前數量(quantity)"
+                            type="hidden"
+                            defaultValue={quantity}
+                            InputProps={{
+                                readOnly: true,
+                            }}
+                        />
+                        <TextField
+                            sx={{
+                                display: "none",
+                            }}
+                            id="read-only-title"
+                            label="商品名稱 (title)"
+                            type="hidden"
+                            value={title}
+                            InputProps={{
+                                readOnly: true,
+                            }}
+                        />
+                        <TextField
+                            multiline
+                            id="desc"
+                            label="商品描述 (desc)"
+                            type="text"
+                            value={desc}
+                            onChange={e => {
+                                handleEditChange(e, "desc")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            multiline
+                            id="deliveryDesc"
+                            label="送貨及付款方式 (deliveryDesc)"
+                            type="text"
+                            value={deliveryDesc}
+                            onChange={e => {
+                                handleEditChange(e, "deliveryDesc")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            multiline
+                            id="tabDesc"
+                            label="商品 Tab 描述 (tabDesc)"
+                            type="text"
+                            value={tabDesc}
+                            onChange={e => {
+                                handleEditChange(e, "tabDesc")
+                            }}
+                            InputLabelProps={{ shrink: true }}
+                        />
+                        <TextField
+                            component="label"
+                            htmlFor="imageUpload"
+                            label={
+                                <Box
+                                    sx={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                    }}>
+                                    上傳商品圖片
+                                    <PhotoCamera />
+                                </Box>
+                            }
+                            inputProps={{
+                                id: "imageUpload",
+                                type: "file",
+                                defaultValue: "",
+                                style: {
+                                    visibility: "hidden",
+                                    zIndex: 999,
+                                },
+                                onChange: e => {
+                                    handleChangeMainImage(e)
+                                },
+                            }}
+                            InputProps={{
+                                startAdornment: (
+                                    <Box
+                                        component="img"
+                                        src={imageUrl !== "" ? imageUrl : PLACEHOLDER_IMG}
                                         sx={{
-                                            display: "none",
-                                        }}
-                                        id="read-only-quantity"
-                                        label="商品目前數量(quantity)"
-                                        type="hidden"
-                                        defaultValue={quantity}
-                                        InputProps={{
-                                            readOnly: true,
+                                            objectFit: "contain",
+                                            width: "250px",
+                                            height: "200px",
                                         }}
                                     />
-                                    <TextField
+                                ),
+                                endAdornment: (
+                                    <Box
                                         sx={{
-                                            display: "none",
-                                        }}
-                                        id="read-only-title"
-                                        label="商品名稱 (title)"
-                                        type="hidden"
-                                        value={title}
-                                        InputProps={{
-                                            readOnly: true,
-                                        }}
-                                    />
-                                    <TextField
-                                        multiline
-                                        id="desc"
-                                        label="商品描述 (desc)"
-                                        type="text"
-                                        value={desc}
-                                        onChange={e => {
-                                            handleEditChange(e, "desc")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        multiline
-                                        id="deliveryDesc"
-                                        label="送貨及付款方式 (deliveryDesc)"
-                                        type="text"
-                                        value={deliveryDesc}
-                                        onChange={e => {
-                                            handleEditChange(e, "deliveryDesc")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        multiline
-                                        id="tabDesc"
-                                        label="商品 Tab 描述 (tabDesc)"
-                                        type="text"
-                                        value={tabDesc}
-                                        onChange={e => {
-                                            handleEditChange(e, "tabDesc")
-                                        }}
-                                        InputLabelProps={{ shrink: true }}
-                                    />
-                                    <TextField
-                                        component="label"
-                                        htmlFor="imageUpload"
-                                        label={
-                                            <Box
-                                                sx={{
-                                                    display: "flex",
-                                                    alignItems: "center",
-                                                }}>
-                                                上傳商品圖片
-                                                <PhotoCamera />
-                                            </Box>
-                                        }
-                                        inputProps={{
-                                            id: "imageUpload",
-                                            type: "file",
-                                            defaultValue: "",
-                                            style: {
-                                                visibility: "hidden",
-                                                zIndex: 999,
-                                            },
-                                            onChange: e => {
-                                                handleChangeMainImage(e)
-                                            },
-                                        }}
-                                        InputProps={{
-                                            startAdornment: (
-                                                <Box
-                                                    component="img"
-                                                    src={imageUrl !== '' ? imageUrl : "https://fakeimg.pl/250x200/?text=預覽圖&font=noto"}
-                                                    sx={{
-                                                        objectFit: "contain",
-                                                        width: "250px",
-                                                        height: "200px",
-                                                    }}
-                                                />
-                                            ),
-                                            endAdornment: (
-                                                <Box
-                                                    sx={{
-                                                        display: "flex",
-                                                        alignItems: "center",
-                                                        cursor: "pointer",
-                                                        position: "absolute",
-                                                        bottom: "5%",
-                                                    }}>
-                                                    <Typography>更新商品圖片</Typography>
-                                                    <PhotoCamera />
-                                                </Box>
-                                            ),
-                                        }}
-                                        sx={{
-                                            ".MuiOutlinedInput-root": {
-                                                paddingTop: "1rem",
-                                                flexDirection: "column",
-                                                cursor: "pointer",
-                                            },
-                                        }}
-                                        error={!!errors?.imageUpload}
-                                        helperText={errors?.imageUpload ? `${errors.imageUpload.message}` : null}
-                                        {...register("imageUpload", {
-                                        })}
-                                    />
-                                    {/* <TextField
+                                            display: "flex",
+                                            alignItems: "center",
+                                            cursor: "pointer",
+                                            position: "absolute",
+                                            bottom: "5%",
+                                        }}>
+                                        <Typography>更新商品圖片</Typography>
+                                        <PhotoCamera />
+                                    </Box>
+                                ),
+                            }}
+                            sx={{
+                                ".MuiOutlinedInput-root": {
+                                    paddingTop: "1rem",
+                                    flexDirection: "column",
+                                    cursor: "pointer",
+                                },
+                            }}
+                            error={!!errors?.imageUpload}
+                            helperText={errors?.imageUpload ? `${errors.imageUpload.message}` : null}
+                            {...register("imageUpload", {})}
+                        />
+                        {/* <TextField
                                         component="label"
                                         htmlFor="tabImageUpload"
                                         label={
@@ -512,25 +529,23 @@ const EditProduct = () => {
                                             handleTabImageUpload(e)
                                         }}
                                     /> */}
-                                </Box>
-                                <Button
-                                    variant="contained"
-                                    disabled={productTitle === ""}
-                                    onClick={handleSubmit(handleEditClick)}
-                                    sx={{
-                                        height: "fit-content",
-                                        width: {
-                                            xs: "68%",
-                                            md: "78%",
-                                            lg: "78%"
-                                        },
-                                    }}
-                                >
-                                    編輯商品
-                                </Button>
-                            </>
-                        )
-                }
+                    </Box>
+                    <Button
+                        variant="contained"
+                        disabled={productTitle === ""}
+                        onClick={handleSubmit(handleEditClick)}
+                        sx={{
+                            height: "fit-content",
+                            width: {
+                                xs: "68%",
+                                md: "78%",
+                                lg: "78%",
+                            },
+                        }}>
+                        編輯商品
+                    </Button>
+                </>
+            }
         </Box>
     )
 }

--- a/src/Components/Dashboard/RemoveProduct.jsx
+++ b/src/Components/Dashboard/RemoveProduct.jsx
@@ -8,8 +8,6 @@ import {
     setRemoveProductTabImageFromStorage,
 } from "../../Utils/firebase"
 import productSlice from "../../Redux/Product/ProductSlice"
-import "react-confirm-alert/src/react-confirm-alert.css"
-import "./removeProduct.css"
 
 const { getProductsData, setRemoveProductDataFromFirestore } = productSlice.actions
 

--- a/src/Components/Dashboard/confirmAlert.css
+++ b/src/Components/Dashboard/confirmAlert.css
@@ -1,0 +1,68 @@
+.react-confirm-alert-overlay {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.react-confirm-alert-body {
+    text-align: center;
+    font-size: 16px;
+    color: #323232;
+    padding: 32px 40px;
+    border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+    max-width: 420px;
+}
+
+.react-confirm-alert-body > h1 {
+    font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 12px;
+}
+
+.react-confirm-alert-button-group {
+    justify-content: center;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.react-confirm-alert-button-group > button {
+    min-width: 96px;
+    padding: 8px 24px;
+    font-size: 15px;
+    font-weight: 500;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.react-confirm-alert-button-group > button:first-child {
+    background-color: #1976d2;
+    color: #fff;
+}
+
+.react-confirm-alert-button-group > button:first-child:hover {
+    background-color: #1565c0;
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+    transform: translateY(-1px);
+}
+
+.react-confirm-alert-button-group > button:first-child:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 6px rgba(25, 118, 210, 0.3);
+}
+
+.react-confirm-alert-button-group > button:not(:first-child) {
+    background-color: #fff;
+    color: #555;
+    border-color: #d1d5db;
+}
+
+.react-confirm-alert-button-group > button:not(:first-child):hover {
+    background-color: #f3f4f6;
+    border-color: #9ca3af;
+}
+
+.react-confirm-alert-button-group > button:focus-visible {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
+}

--- a/src/Components/Dashboard/constants.js
+++ b/src/Components/Dashboard/constants.js
@@ -1,0 +1,2 @@
+export const PLACEHOLDER_IMG =
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='250' height='200'><rect width='250' height='200' fill='%23f5f5f5'/><rect x='40' y='35' width='170' height='130' rx='8' fill='none' stroke='%23c0c0c0' stroke-width='2'/><circle cx='80' cy='75' r='10' fill='%23c0c0c0'/><path d='M55 155 L110 100 L145 135 L170 115 L205 155 Z' fill='%23c0c0c0'/><text x='125' y='185' text-anchor='middle' font-family='sans-serif' font-size='14' fill='%239e9e9e'>Preview</text></svg>"

--- a/src/Components/Dashboard/removeProduct.css
+++ b/src/Components/Dashboard/removeProduct.css
@@ -1,8 +1,0 @@
-.react-confirm-alert-body {
-    text-align: center;
-    font-size: 20px;
-}
-
-.react-confirm-alert-button-group {
-    justify-content: center;
-}

--- a/src/Redux/Product/ProductSaga.js
+++ b/src/Redux/Product/ProductSaga.js
@@ -7,7 +7,9 @@ import {
     getTabImagesFromStorage,
     setProductDataToFirestore,
     setUpdateSelectedProductToFirestore,
-    setRemoveProductDataFromFirestore
+    setRemoveProductDataFromFirestore,
+    uploadProductMainImage,
+    setProductTabImageToStorage
 } from "../../Utils/firebase"
 import showAlert from '../../Components/Alert/Alert'
 
@@ -82,7 +84,23 @@ export function* setProductDataToFirestoreSaga(action) {
 
 export function* setUpdateSelectedProductToFirestoreSaga(action) {
     try {
-        const data = yield call(setUpdateSelectedProductToFirestore, action.payload)
+        const { imageFile, fileLength, tabImageFiles, ...rest } = action.payload
+
+        // 先把新主圖上傳到 Storage 拿真實 download URL，再寫 Firestore，避免 blob URL 落地
+        // 註：File 實例的屬性（name、size）都在 prototype 上，Object.keys(file) 永遠是 []，故改用 instanceof
+        let mainImgOverride = {}
+        if (fileLength && fileLength > 0 && imageFile instanceof File) {
+            mainImgOverride = yield call(uploadProductMainImage, imageFile, rest.title)
+        }
+
+        if (tabImageFiles && tabImageFiles.length > 0) {
+            yield call(setProductTabImageToStorage, tabImageFiles)
+        }
+
+        const data = yield call(setUpdateSelectedProductToFirestore, {
+            ...rest,
+            ...mainImgOverride,
+        })
         yield put({ type: setUpdateSelectedProductToFirestoreSuccess.type, payload: data })
         yield call(showAlert, '商品編輯成功', 'success')
         yield put(getProductsData())

--- a/src/Redux/Product/ProductSlice.js
+++ b/src/Redux/Product/ProductSlice.js
@@ -49,6 +49,24 @@ export const productSlice = createSlice({
 
         getProductsDataSuccess(state, action) {
             state.productsData = action.payload
+
+            // orderList 以 productId 為穩定 key 重新對齊最新 productsData；
+            // 商品被編輯（改名 / 換圖 / 改價）→ 同步覆蓋；被刪除 → 從購物車移除。
+            if (state.orderList.length > 0) {
+                state.orderList = state.orderList
+                    .map(item => {
+                        const fresh = action.payload.find(p => p.productId === item.productId)
+                        if (!fresh) return null
+                        return {
+                            ...item,
+                            title: fresh.title,
+                            mainImg: fresh.mainImg,
+                            stock: fresh.stock,
+                            discountPrice: fresh.discountPrice,
+                        }
+                    })
+                    .filter(Boolean)
+            }
         },
 
         setDelayLoading(state, action) {

--- a/src/Utils/firebase.js
+++ b/src/Utils/firebase.js
@@ -10,18 +10,18 @@ import {
     GoogleAuthProvider,
     sendPasswordResetEmail,
 } from "firebase/auth"
-import { getFirestore, updateDoc, deleteDoc, collection, getDocs, setDoc, doc } from "firebase/firestore"
+import { getFirestore, updateDoc, deleteDoc, collection, getDocs, setDoc, doc, writeBatch } from "firebase/firestore"
 
 const db = getFirestore()
 const storage = getStorage()
 const app = initializeApp(firebaseConfig)
 
 const setUpdateSelectedProductToFirestore = async (
-    { title, productId, originalPrice, discountPrice, desc, tabDesc, deliveryDesc, stock, quantity, imageFileName, mainImg },
+    { originalTitle, title, productId, originalPrice, discountPrice, desc, tabDesc, deliveryDesc, stock, quantity, imageFileName, mainImg },
     callBack
 ) => {
     try {
-        await updateDoc(doc(db, "products", title), {
+        const payload = {
             title,
             productId,
             originalPrice,
@@ -32,11 +32,23 @@ const setUpdateSelectedProductToFirestore = async (
             stock,
             quantity,
             imageFileName,
-            mainImg
-        })
+            mainImg,
+        }
+
+        // doc ID 綁定於 title，改名時 updateDoc 會因目標 doc 不存在而丟錯；
+        // 用 batch 原子執行「建新 doc + 刪舊 doc」避免中間狀態不一致。
+        if (originalTitle && originalTitle !== title) {
+            const batch = writeBatch(db)
+            batch.set(doc(db, "products", title), payload)
+            batch.delete(doc(db, "products", originalTitle))
+            await batch.commit()
+        } else {
+            await updateDoc(doc(db, "products", title), payload)
+        }
         callBack && callBack()
     } catch (err) {
         console.error("Error: ", err)
+        throw err
     }
 }
 
@@ -207,20 +219,13 @@ const setProductImageToStorage = async (imageFile, productName) => {
 //     }
 // }
 
-const setUploadProductImageToStorage = async (imageFile, productTitle, fileLength) => {
-    if (!fileLength || fileLength === 0) return
-
+// 純粹上傳主圖到 Storage，回傳下載 URL 與儲存檔名；不寫 Firestore，由 caller 決定寫入時機與目標 doc
+const uploadProductMainImage = async (imageFile, productTitle) => {
     const storageFileName = buildStorageFileName(imageFile, productTitle)
     const imageRef = ref(storage, `Images/products/${storageFileName}`)
-
-    try {
-        await uploadBytes(imageRef, imageFile, IMAGE_UPLOAD_METADATA)
-        const downloadURL = await getDownloadURL(imageRef)
-        const productDocRef = doc(db, "products", productTitle)
-        await updateDoc(productDocRef, { mainImg: downloadURL, imageFileName: storageFileName })
-    } catch (error) {
-        console.error("Error uploading file or updating database:", error)
-    }
+    await uploadBytes(imageRef, imageFile, IMAGE_UPLOAD_METADATA)
+    const downloadURL = await getDownloadURL(imageRef)
+    return { mainImg: downloadURL, imageFileName: storageFileName }
 }
 
 const setProductTabImageToStorage = async imageFiles => {
@@ -392,7 +397,7 @@ export {
     setRemoveProductDataFromFirestore,
     setProductImageToStorage,
     setProductDataToFirestore,
-    setUploadProductImageToStorage,
+    uploadProductMainImage,
     setProductTabImageToStorage,
     getProductListFromFirestore,
     getTabImagesFromStorage,


### PR DESCRIPTION
## 動機

Dashboard 的新增 / 編輯商品流程同時踩到幾個問題：
1. 主圖預覽的 placeholder 連不上外部服務，畫面顯示破圖
2. confirmAlert 彈窗的「是 / 否」按鈕過小、主次動作沒視覺差異
3. 上傳或編輯完成後表單不會自動清空
4. **改名**存不回 Firestore、**改名＋換圖**主圖會壞

本 PR 一次處理上述四組症狀。

## 改動摘要

### Commit 1 — style(dashboard): polish confirmAlert modal and relocate CSS to route root
- `removeProduct.css` 改名為 `confirmAlert.css`，標示它其實對所有 confirmAlert 彈窗生效
- 模態框、標題、訊息與按鈕樣式重整：主要按鈕用 MUI 主色填色，次要按鈕用白底灰邊，加入 hover / active / focus-visible 狀態
- CSS 的 import 從 `RemoveProduct.jsx` 移到 `Dashboard.jsx` route 進入點，未來導入 code splitting 也不會遺失樣式

### Commit 2 — fix(dashboard): product CRUD form lifecycle and rename+reupload race
**2.1 預覽圖**：新增 `constants.js`，匯出 inline SVG data URI 的 `PLACEHOLDER_IMG`，完全去除外部依賴。

**2.2 表單清空**：用 `submittedRef` 追蹤送出狀態，搭配監聽 `productsData` 變化作為成功訊號（saga 成功後會 `getProductsData()` 觸發），只在真的成功才清欄位、file input DOM value、RHF 內部狀態。失敗保留輸入供重試。

**2.3 改名存不回**：`products` doc ID 綁在 `title`，原本的 `updateDoc` 對不存在的新名 doc 丟錯但被靜默吞掉。改用 `writeBatch` 原子執行「set 新 doc + delete 舊 doc」，錯誤改為 `throw` 讓 saga 能走 Failure 路徑。

**2.4 改名＋換圖 race**：
- `firebase.js` 拆出純上傳函式 `uploadProductMainImage`，刪掉職責混合的 `setUploadProductImageToStorage`
- saga 接管順序：先 await 上傳拿真實 download URL、再 await 寫 Firestore
- EditProduct 不再直接呼叫 firebase helper
- 守衛用 `imageFile instanceof File`（原本的 `Object.keys(file).length > 0` 對 File 實例永遠是 `[]`，會誤跳過上傳）

## 測試方式

| 情境 | 預期 |
|------|------|
| 新增商品並上傳圖 | 成功後彈窗訊息顯示、表單清空、列表出現新商品 |
| 編輯只改文字欄位 | 列表顯示新文字，主圖不變 |
| 編輯只換主圖 | 列表顯示新圖，名稱不變 |
| 編輯只改名 | 列表顯示新名稱，主圖仍正常 |
| **編輯同時改名＋換圖** | 列表顯示新名稱＋新圖，重新整理仍正常 |
| 編輯失敗（例如關網路） | 不顯示「編輯成功」alert、表單保留輸入可重試 |

## 風險與回滾

- `setUpdateSelectedProductToFirestore` 函式簽章新增 `originalTitle` 參數，caller 只有 EditProduct，已同步更新
- `setUploadProductImageToStorage` 被刪除，僅 EditProduct 使用已改走 saga 協調
- 回滾：revert 兩個 commit 即可，無 migration
- 已知殘留技術債（另開 issue 追蹤）：
  - 改名時 Storage 舊圖檔未清理（URL 正確不影響顯示，只是 orphan）
  - 根因是 doc ID 用 title，未來 Plan B 考慮改用 productId